### PR TITLE
add trend tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ emoji: 🏆
 colorFrom: yellow
 colorTo: green
 sdk: gradio
-sdk_version: 4.40.0
+sdk_version: 5.8.0
 app_file: app.py
 pinned: false
 ---

--- a/app.py
+++ b/app.py
@@ -8,15 +8,14 @@ from src.assets.text_content import TITLE, INTRODUCTION_TEXT, CLEMSCORE_TEXT, MU
 from src.leaderboard_utils import query_search, get_github_data
 from src.plot_utils import split_models, plotly_plot, get_plot_df, update_open_models, update_closed_models
 from src.plot_utils import reset_show_all, reset_show_names, reset_show_legend, reset_mobile_view
-from src.version_utils import get_versions_data
+from src.version_utils import get_version_data
+from src.trend_utils import get_final_trend_plot
 
 """ 
 CONSTANTS
 """
 # For restarting the gradio application every 24 Hrs
 TIME = 43200  # in seconds # Reload will not work locally - requires HFToken # The app launches locally as expected - only without the reload utility
-# For Leaderboard table
-dataframe_height = 800  # Height of the table in pixels # Set on average considering all possible devices
 
 
 """
@@ -33,26 +32,27 @@ def restart_space():
 GITHUB UTILS
 """
 github_data = get_github_data()
-multimodal_leaderboard = github_data["multimodal"][0]  # Get multimodal leaderboard for its available latest version.
+multimodal_leaderboard = github_data["multimodal"]["dataframes"][0]  # Get the latest version of multimodal leaderboard
 
-# Show only First 4 columns for the leaderboards
+# Show only First 4 columns for the leaderboard
+# Should be Model Name, Clemscore, %Played, and Quality Score
 multimodal_leaderboard = multimodal_leaderboard.iloc[:, :4]
-print(f"Showing the following columns for the multimodal leaderboard: {multimodal_leaderboard.columns}")
 
 
 """
 VERSIONS UTILS
 """
-versions_data = get_versions_data()
-latest_version = versions_data['latest']  # Always show latest version in text-only benchmark
-last_updated_date = versions_data['date']
-version_names = list(versions_data.keys())
-version_names = [v for v in version_names if v.startswith("v")]  # Remove "latest" and "date" keys
+versions_data = get_version_data()
+latest_version = versions_data['versions'][0]['name']
+last_updated_date = versions_data['versions'][0]['last_updated'][0]
+version_names = [v['name'] for v in versions_data['versions']]
 
 global version_df
-version_df = versions_data[latest_version]
+version_df = versions_data['dataframes'][0]
 def select_version_df(name):
-    return versions_data[name]
+    for i, v in enumerate(versions_data['versions']):
+        if v['name'] == name:
+            return versions_data['dataframes'][i]
 
 """
 MAIN APPLICATION
@@ -64,10 +64,8 @@ with hf_app:
     gr.Markdown(INTRODUCTION_TEXT, elem_classes="markdown-text")
 
     with gr.Tabs(elem_classes="tab-buttons") as tabs:
-
-
         """
-        #######################       SECOND TAB - MULTIMODAL LEADERBOARD     #######################
+        #######################       FIRST TAB - MULTIMODAL LEADERBOARD     #######################
         """
         with gr.TabItem(MULTIMODAL_NAME, elem_id="mm-llm-benchmark-tab-table", id=1):
             with gr.Row():
@@ -81,13 +79,12 @@ with hf_app:
                 value=multimodal_leaderboard,
                 elem_id="mm-leaderboard-table",
                 interactive=False,
-                visible=True,
-                height=dataframe_height
+                visible=True
             )
 
             # Show information about the clemscore and last updated date below the table
             gr.HTML(CLEMSCORE_TEXT)
-            gr.HTML(f"Last updated - {github_data['date']}")
+            gr.HTML(f"Last updated - {github_data['multimodal']['version_data'][0]['last_updated'][0]}")
 
             # Add a dummy leaderboard to handle search queries in leaderboard_table
             # This will show a temporary leaderboard based on the searched value
@@ -107,10 +104,9 @@ with hf_app:
             )
 
         """
-        #######################       THIRD TAB - PLOTS - %PLAYED V/S QUALITY SCORE     #######################
+        #######################       SECOND TAB - PLOTS - %PLAYED V/S QUALITY SCORE     #######################
         """
-        with gr.TabItem("📈 Plots", elem_id="plots", id=2):
-
+        with gr.TabItem("📊 Plots", elem_id="plots", id=2):
             """
             Accordion Groups to select individual models - Hidden by default
             """
@@ -229,7 +225,6 @@ with hf_app:
                 queue=True
             )
 
-
             open_models_selection.change(
                 reset_show_all,
                 outputs=[show_all],
@@ -242,11 +237,37 @@ with hf_app:
                 queue=True
             )
 
+        """
+        #######################       THIRD TAB - TRENDS     #######################
+        """
+        with gr.TabItem("📈Trends", elem_id="trends-tab", id=3):
+            with gr.Row():
+                mkd_text = gr.Markdown("### Commercial v/s Open-Weight models - clemscore over time.  The size of the circles represents the scaled value of the parameters of the models. Larger circles indicate higher parameter values.")
 
+            with gr.Row():
+                trend_plot = gr.Plot(get_final_trend_plot(False, 1200), show_label=False)
+
+            with gr.Row():
+                mobile_view = gr.CheckboxGroup(
+                    choices=["Mobile View"],
+                    value=[],
+                    label="View plot on smaller screens 📱",
+                    elem_id="value-select-8",
+                    interactive=True,
+                )
+
+            mobile_view.change(
+                get_final_trend_plot,
+                [mobile_view],
+                [trend_plot],
+                queue=True
+            )
+ 
+            
         """
         #######################       FOURTH TAB - VERSIONS AND DETAILS     #######################
         """
-        with gr.TabItem("🔄 Versions and Details", elem_id="versions-details-tab", id=3):
+        with gr.TabItem("🔄 Versions and Details", elem_id="versions-details-tab", id=4):
             with gr.Row():
                 version_select = gr.Dropdown(
                     version_names, label="Select Version 🕹️", value=latest_version
@@ -262,8 +283,7 @@ with hf_app:
                 value=version_df,
                 elem_id="version-leaderboard-table",
                 interactive=False,
-                visible=True,
-                height=dataframe_height
+                visible=True
             )
 
             dummy_prev_table = gr.Dataframe(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gradio==4.40.0
+gradio==5.8.0
 pandas==2.2.2
 plotly==5.18.0
 apscheduler==3.10.4

--- a/src/assets/text_content.py
+++ b/src/assets/text_content.py
@@ -1,6 +1,6 @@
 TITLE = """<h1 align="center" id="space-title"> 🏆 Multimodal CLEM Leaderboard</h1>"""
 
-REPO = "https://raw.githubusercontent.com/kushal-10/clembench-runs/main/"
+REPO = "https://raw.githubusercontent.com/clembench/clembench-runs/main/"
 HF_REPO = "colab-potsdam/multimodal-clem-leaderboard"
 REGISTRY_URL = "https://raw.githubusercontent.com/clp-research/clembench/refs/heads/main/backends/model_registry.json"
 BENCHMARK_FILE = "benchmark_runs.json"

--- a/src/assets/text_content.py
+++ b/src/assets/text_content.py
@@ -1,7 +1,9 @@
 TITLE = """<h1 align="center" id="space-title"> 🏆 Multimodal CLEM Leaderboard</h1>"""
 
-REPO = "https://raw.githubusercontent.com/clembench/clembench-runs/main/"
-HF_REPO = "colab-potsdam/clem-leaderboard"
+REPO = "https://raw.githubusercontent.com/kushal-10/clembench-runs/main/"
+HF_REPO = "colab-potsdam/multimodal-clem-leaderboard"
+REGISTRY_URL = "https://raw.githubusercontent.com/clp-research/clembench/refs/heads/main/backends/model_registry.json"
+BENCHMARK_FILE = "benchmark_runs.json"
 
 TEXT_NAME = "🥇 CLEM Leaderboard"
 MULTIMODAL_NAME = "🥇 Multimodal CLEM Leaderboard"

--- a/src/leaderboard_utils.py
+++ b/src/leaderboard_utils.py
@@ -5,11 +5,12 @@ import json
 from io import StringIO
 from datetime import datetime
 
-from src.assets.text_content import REPO
+from src.assets.text_content import REPO, BENCHMARK_FILE
 
 def get_github_data():
     """
-    Read and process data from CSV files hosted on GitHub. - https://github.com/clembench/clembench-runs
+    Read and process data from CSV files hosted on GitHub. - https://github.com/clembench/clembench-runs (REPO)
+    Set the path in src/assets/text_content/REPO
 
     Returns:
         github_data (dict): Dictionary containing:
@@ -17,54 +18,60 @@ def get_github_data():
             - "multimodal": List of DataFrames for each version's multimodal leaderboard data.
             - "date": Formatted date of the latest version in "DD Month YYYY" format.
     """
-    base_repo = REPO
-    json_url = base_repo + "benchmark_runs.json"
+    json_url = REPO + BENCHMARK_FILE
     response = requests.get(json_url)
 
     # Check if the JSON file request was successful
     if response.status_code != 200:
-        print(f"Failed to read JSON file: Status Code: {response.status_code}")
+        print(f"Failed to read JSON file - {BENCHMARK_FILE} in repo {REPO}: Status Code: {response.status_code}")
         return None, None, None, None
 
     json_data = response.json()
     versions = json_data['versions']
 
+    # Sort the versions in benchmark by latest first
     version_names = sorted(
         [ver['version'] for ver in versions],
-        key=lambda v: list(map(int, v[1:].split('_')[0].split('.'))),  # {{ edit_1 }}: Corrected slicing to handle 'v' prefix
+        key=lambda v: list(map(int, v[1:].split('_')[0].split('.'))),  
         reverse=True
     )   
 
-    # Get Last updated date of the latest version
-    latest_version = version_names[0]
-    latest_date = next(
-        ver['date'] for ver in versions if ver['version'] == latest_version
-    )
-    formatted_date = datetime.strptime(latest_date, "%Y-%m-%d").strftime("%d %b %Y")  # {{ edit_1 }}: Updated date format
+    # Collect Dataframes - Text and Multimodal Only - Ignoring _quantized, _backends, _ascii
+    text_data = {
+        'version_data': [],
+        'dataframes': []
+    }
+    multimodal_data = {
+        'version_data': [],
+        'dataframes': []
+    }
 
-    # Get Leaderboard data - for text-only + multimodal
-    github_data = {}
-
-    mm_dfs = []
-    mm_date = ""
-    mm_flag = True
     for version in version_names:
-        # Check if version ends with 'multimodal' before constructing the URL
-        mm_suffix = "_multimodal" if not version.endswith('multimodal') else ""
-        mm_url = f"{base_repo}{version}{mm_suffix}/results.csv"  # {{ edit_1 }}: Conditional suffix for multimodal
-        mm_response = requests.get(mm_url)
-        if mm_response.status_code == 200:
-            df = pd.read_csv(StringIO(mm_response.text))
+        results_url = f"{REPO}{version}/results.csv"
+        csv_response = requests.get(results_url)
+        if csv_response.status_code == 200:
+            df = pd.read_csv(StringIO(csv_response.text))
             df = process_df(df)
-            df = df.sort_values(by=df.columns[1], ascending=False) # Sort by clemscore column
-            mm_dfs.append(df)
-            if mm_flag:
-                mm_date = next(ver['date'] for ver in versions if ver['version'] == version)
-                mm_date = datetime.strptime(mm_date, "%Y-%m-%d").strftime("%d %b %Y")
-                mm_flag = False
+            df = df.sort_values(by=df.columns[1], ascending=False) # Sort by Clemscore
 
-    github_data["multimodal"] = mm_dfs
-    github_data["date"] = mm_date
+            version_data = {
+                'name': version,
+                'last_updated': [datetime.strptime(v['last_updated'], '%Y-%m-%d').strftime("%d %b %Y") for v in versions if v['version'] == version],
+                'release_date': [datetime.strptime(v['release_date'], '%Y-%m-%d').strftime("%d %b %Y") for v in versions if v['version'] == version]
+            } 
+
+            if 'multimodal' in version:
+                multimodal_data['dataframes'].append(df)
+                multimodal_data['version_data'].append(version_data)
+            else:
+                text_data['dataframes'].append(df)
+                text_data['version_data'].append(version_data)
+
+      
+    github_data = {
+        'text': text_data,
+        'multimodal': multimodal_data
+    }
 
     return github_data
 
@@ -123,3 +130,8 @@ def query_search(df: pd.DataFrame, query: str) -> pd.DataFrame:
     filtered_df = df[df['Model'].str.lower().str.contains('|'.join(queries))]
 
     return filtered_df
+
+if __name__=='__main__':
+    data = get_github_data()
+    print(data['text']['version_data'])
+    print(data['multimodal']['version_data'])

--- a/src/plot_utils.py
+++ b/src/plot_utils.py
@@ -4,7 +4,7 @@ import requests
 import json
 import gradio as gr
 
-from src.assets.text_content import SHORT_NAMES, TEXT_NAME, MULTIMODAL_NAME
+from src.assets.text_content import SHORT_NAMES, TEXT_NAME, MULTIMODAL_NAME, REGISTRY_URL
 from src.leaderboard_utils import get_github_data
 
 
@@ -131,8 +131,7 @@ def split_models(model_list: list):
     commercial_models = []
     
     # Load model registry data from main repo
-    model_registry_url = "https://raw.githubusercontent.com/clp-research/clembench/main/backends/model_registry.json"
-    response = requests.get(model_registry_url)
+    response = requests.get(REGISTRY_URL)
 
     if response.status_code == 200:
         json_data = json.loads(response.text)
@@ -163,7 +162,7 @@ def split_models(model_list: list):
 """
 Update Functions, for when the leaderboard selection changes
 """
-def update_open_models(leaderboard: str = TEXT_NAME):
+def update_open_models():
     """
     Change the checkbox group of Open Models based on the leaderboard selected
 
@@ -173,9 +172,9 @@ def update_open_models(leaderboard: str = TEXT_NAME):
         Updated checkbox group for Open Models, based on the leaderboard selected
     """
     github_data = get_github_data()
-    leaderboard_data = github_data["multimodal"][0]
+    leaderboard_data = github_data["multimodal"]['dataframes'][0]
     models = leaderboard_data.iloc[:, 0].unique().tolist()
-    open_models, commercial_models = split_models(models)
+    open_models, _ = split_models(models)
     return gr.CheckboxGroup(
         open_models,
         value=[],
@@ -183,7 +182,7 @@ def update_open_models(leaderboard: str = TEXT_NAME):
         interactive=True,
     )
 
-def update_closed_models(leaderboard: str = TEXT_NAME):
+def update_closed_models():
     """
     Change the checkbox group of Closed Models based on the leaderboard selected
 
@@ -193,9 +192,9 @@ def update_closed_models(leaderboard: str = TEXT_NAME):
         Updated checkbox group for Closed Models, based on the leaderboard selected
     """
     github_data = get_github_data()
-    leaderboard_data = github_data["multimodal"][0]
+    leaderboard_data = github_data["multimodal"]['dataframes'][0]
     models = leaderboard_data.iloc[:, 0].unique().tolist()
-    open_models, commercial_models = split_models(models)
+    _, commercial_models = split_models(models)
     return gr.CheckboxGroup(
         commercial_models,
         value=[],
@@ -203,7 +202,7 @@ def update_closed_models(leaderboard: str = TEXT_NAME):
         interactive=True,
     )
 
-def get_plot_df(leaderboard: str = TEXT_NAME) -> pd.DataFrame:
+def get_plot_df() -> pd.DataFrame:
     """
     Get the DataFrame for plotting based on the selected leaderboard.
     Args:
@@ -212,7 +211,7 @@ def get_plot_df(leaderboard: str = TEXT_NAME) -> pd.DataFrame:
         DataFrame with model data.
     """
     github_data = get_github_data()
-    return github_data["multimodal"][0]
+    return github_data["multimodal"]['dataframes'][0]
 
 
 """

--- a/src/trend_utils.py
+++ b/src/trend_utils.py
@@ -1,0 +1,402 @@
+## Fetch Model Registry and clemscores
+import requests
+import pandas as pd
+from datetime import datetime
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import numpy as np
+
+from src.assets.text_content import REGISTRY_URL, REPO, BENCHMARK_FILE
+from src.leaderboard_utils import get_github_data
+
+# Cut-off date from where to start the trendgraph
+START_DATE = '2023-06-01'
+
+def get_param_size(params: str) -> float:
+    """Convert parameter size from string to float.
+
+    Args:
+        params (str): The parameter size as a string (e.g., '1000B', '1T').
+
+    Returns:
+        float: The size of parameters in float.
+    """
+    if not params:
+        param_size = 0
+    else:
+        if params[-1] == "B":
+            param_size = params[:-1]
+            param_size = float(param_size)
+        elif params[-1] == "T":
+            param_size = params[:-1]
+            param_size = float(param_size)
+            param_size *= 1000
+        else:
+            print("Not a valid parameter size")
+
+    return param_size
+
+def date_difference(date_str1: str, date_str2: str) -> int:
+    """Calculate the difference in days between two dates.
+
+    Args:
+        date_str1 (str): The first date as a string in 'YYYY-MM-DD' format.
+        date_str2 (str): The second date as a string in 'YYYY-MM-DD' format.
+
+    Returns:
+        int: The difference in days between the two dates.
+    """
+    date_format = "%Y-%m-%d"
+    date1 = datetime.strptime(date_str1, date_format)
+    date2 = datetime.strptime(date_str2, date_format)
+    return (date1 - date2).days
+
+
+def populate_list(df: pd.DataFrame, abs_diff: float) -> list:
+    """Create a list of models based on clemscore differences.
+
+    Args:
+        df (pd.DataFrame): DataFrame containing model data.
+        abs_diff (float): The absolute difference threshold for clemscore.
+
+    Returns:
+        list: A list of model names that meet the criteria.
+    """
+    l = [df.iloc[0]['model']]
+    prev_clemscore = df.iloc[0]['clemscore']
+    prev_date = df.iloc[0]['release_date']
+
+    for i in range(1, len(df)):
+        curr_clemscore = df.iloc[i]['clemscore']
+        curr_date = df.iloc[i]['release_date']
+        date_diff = date_difference(curr_date, prev_date)
+
+        if curr_clemscore - prev_clemscore >= abs_diff:
+            if date_diff == 0:
+                l[-1] = df.iloc[i]['model']
+            else:
+                l.append(df.iloc[i]['model'])
+
+            prev_clemscore = curr_clemscore
+            prev_date = curr_date
+
+    # # Add the last model if the difference between the last and previous date is greater than 15 days
+    # last_date = df.iloc[-1]['release_date']
+    # if date_difference(last_date, prev_date) > 15:
+    #     l.append(df.iloc[-1]['model'])
+
+    return l
+
+
+def get_models_to_display(result_df: pd.DataFrame, open_dip: float = 0, comm_dip: float = 0) -> tuple:
+    """Retrieve models to display based on clemscore differences.
+
+    Args:
+        result_df (pd.DataFrame): DataFrame containing model data.
+        open_dip (float, optional): Threshold for open models. Defaults to 0.
+        comm_dip (float, optional): Threshold for commercial models. Defaults to 0.
+
+    Returns:
+        tuple: Two lists of model names (open and commercial).
+    """
+    open_model_df = result_df[result_df['open_weight']==True]
+    comm_model_df = result_df[result_df['open_weight']==False]
+
+    open_model_df = open_model_df.sort_values(by='release_date', ascending=True)
+    comm_model_df = comm_model_df.sort_values(by='release_date', ascending=True)
+    open_models = populate_list(open_model_df, open_dip)
+    comm_models = populate_list(comm_model_df, comm_dip)
+    return open_models, comm_models
+
+
+def get_trend_data(text_dfs: list, model_registry_data: list) -> pd.DataFrame:
+    """Process text data frames to extract model information.
+
+    Args:
+        text_dfs (list): List of DataFrames containing model information.
+        model_registry_data (list): List of dictionaries containing model registry data.
+
+    Returns:
+        pd.DataFrame: DataFrame containing processed model data.
+    """
+    visited = set()  # Track models that have been processed
+    result_df = pd.DataFrame(columns=['model', 'clemscore', 'open_weight', 'release_date', 'parameters', 'est_flag'])
+
+    for df in text_dfs:
+        for i in range(len(df)):
+            model_name = df['Model'].iloc[i]
+            if model_name not in visited:
+                visited.add(model_name)
+                for dict_obj in model_registry_data:
+                    if dict_obj["model_name"] == model_name:
+                        if dict_obj["parameters"] == "" :
+                            params = "1000B"
+                            est_flag = True
+                        else:
+                            params = dict_obj['parameters']
+                            est_flag = False
+
+                        param_size = get_param_size(params)
+                        new_data = {'model': model_name, 'clemscore': df['Clemscore'].iloc[i], 'open_weight':dict_obj['open_weight'],
+                                    'release_date': dict_obj['release_date'], 'parameters': param_size, 'est_flag': est_flag}
+                        result_df.loc[len(result_df)] = new_data
+                        break
+    return result_df  # Return the compiled DataFrame
+
+
+def get_plot(df: pd.DataFrame, start_date: str = '2023-06-01', end_date: str = '2024-12-30',
+             benchmark_ticks: dict = {}, benchmark_update = {}, **plot_kwargs) -> go.Figure:
+    """Generate a scatter plot for the given DataFrame.
+
+    Args:
+        df (pd.DataFrame): DataFrame containing model data.
+        start_date (str, optional): Start date for filtering. Defaults to '2023-06-01'.
+        end_date (str, optional): End date for filtering. Defaults to '2024-12-30'.
+        benchmark_ticks (dict, optional): Custom benchmark ticks for the version dates. Defaults to {}.
+        benchmark_update (dict, optional): Custom benchmark metadata containing last_updated date for the versions. Defaults to {}.
+    
+    Keyword Args:
+        open_dip (float, optional): Threshold for open models' clemscore differences. Max dip in clemscore allowed to be considered in trend.
+        comm_dip (float, optional): Threshold for commercial models' clemscore differences. Max dip in clemscore allowed to be considered in trend.
+        height (int, optional): Height of the plot in pixels. Adjusted for mobile or desktop views.
+        mobile_view (bool, optional): Flag to indicate if the plot should be optimized for mobile display. Defaults to False.
+
+    Returns:
+        go.Figure: The generated plot.
+    """
+
+    open_dip = plot_kwargs['open_dip']
+    comm_dip = plot_kwargs['comm_dip']
+    height = plot_kwargs['height']
+    width = plot_kwargs['width']
+
+    mobile_view = True if plot_kwargs['mobile_view'] else False
+
+    max_clemscore = df['clemscore'].max()
+    # Convert 'release_date' to datetime
+    df['Release date'] = pd.to_datetime(df['release_date'], format='ISO8601')
+    # Filter out data before April 2023/START_DATE
+    df = df[df['Release date'] >= pd.to_datetime(start_date)]
+    open_model_list, comm_model_list = get_models_to_display(df, open_dip, comm_dip)    
+    models_to_display = open_model_list + comm_model_list
+    print(f"open_model_list: {open_model_list}, comm_model_list: {comm_model_list}")
+
+    # Create a column to indicate if the model should be labeled
+    df['label_model'] = df['model'].apply(lambda x: x if x in models_to_display else "")
+
+    # If mobile_view, then show only the models in models_to_display i.e. on the trend line #minimalistic
+    if mobile_view:
+        df = df[df['model'].isin(models_to_display)]
+
+    # Add an identifier column to each DataFrame
+    df['Model Type'] = df['open_weight'].map({True: 'Open-Weight', False: 'Commercial'})
+
+    marker_size = df['parameters'].apply(lambda x: np.sqrt(x) if x > 0 else np.sqrt(400)).astype(float)  # Arbitrary sqrt value to scale marker size based on parameter size
+
+    open_color = 'red'
+    comm_color = 'blue'
+
+    # Create the scatter plot
+    fig = px.scatter(df,
+                    x="Release date",
+                    y="clemscore",
+                    color="Model Type",  # Differentiates the datasets by color
+                    hover_name="model",
+                    size=marker_size,
+                    size_max=40,  # Max size of the circles
+                    template="plotly_white",
+                    hover_data={  # Customize hover information
+                        "Release date": True,  # Show the release date
+                        "clemscore": True,  # Show the clemscore
+                        "Model Type": True  # Show the model type
+                    },
+                    custom_data=["model", "Release date", "clemscore"]  # Specify custom data columns for hover
+                    )
+
+    fig.update_traces(
+        hovertemplate='Model Name: %{customdata[0]}<br>Release date: %{customdata[1]}<br>Clemscore: %{customdata[2]}<br>'
+    )
+    
+    # Sort dataframes for line plotting
+    df_open = df[df['model'].isin(open_model_list)].sort_values(by='Release date')
+    df_commercial = df[df['model'].isin(comm_model_list)].sort_values(by='Release date')
+
+    ## Custom tics for x axis
+    # Define the start and end dates
+    start_date = pd.to_datetime(start_date)
+    end_date = pd.to_datetime(end_date)
+    # Generate ticks every two months
+    date_range = pd.date_range(start=start_date, end=end_date, freq='2MS')  # '2MS' stands for 2 Months Start frequency
+    # Create labels for these ticks
+    custom_ticks = {date: date.strftime('%b %Y') for date in date_range}
+
+    ## Benchmark Version ticks
+    benchmark_tickvals = list(pd.to_datetime(list(benchmark_ticks.keys())))
+    custom_ticks = {k:v for k,v in custom_ticks.items() if k not in benchmark_tickvals}
+    custom_tickvals = list(custom_ticks.keys())
+
+
+    for date, version in benchmark_ticks.items():
+        # Find the corresponding update date from benchmark_update based on the version name
+        update_date = next((update_date for update_date, ver in benchmark_update.items() if version in ver), None)
+
+        if update_date:
+            # Add vertical black dotted line for each benchmark_tick date
+            fig.add_shape(
+                go.layout.Shape(
+                    type='line',
+                    x0=date,
+                    x1=date,
+                    y0=0,
+                    y1=1,
+                    yref='paper',
+                    line=dict(color='#A9A9A9', dash='dash'),  # Black dotted line
+                )
+            )
+
+            # Add hover information across the full y-axis range
+            fig.add_trace(
+                go.Scatter(
+                    x=[date]*100,
+                    y=list(range(0,100)),  # Covers full y-axis range
+                    mode='markers',
+                    line=dict(color='rgba(255,255,255,0)', width=0),  # Fully transparent line
+                    hovertext=[
+                        f"Version: {version} released on {date.strftime('%d %b %Y')}, last updated on: {update_date.strftime('%d %b %Y')}" 
+                        for _ in range(100)
+                    ],  # Unique hovertext for all points
+                    hoverinfo="text",
+                    hoveron='points',
+                    showlegend=False
+                )
+            )
+
+
+    if mobile_view:
+        # Remove custom_tickvals within -1 month to +1 month of benchmark_tickvals for better visibility
+        one_month = pd.DateOffset(months=1)
+        filtered_custom_tickvals = [
+            date for date in custom_tickvals 
+            if not any((benchmark_date - one_month <= date <= benchmark_date + one_month) for benchmark_date in benchmark_tickvals)
+        ]
+        # Alternate <br> for benchmark ticks based on date difference (Eg. v1.6, v1.6.5 too close to each other for MM benchmark)
+        benchmark_tick_texts = []
+        for i in range(len(benchmark_tickvals)):
+            if i == 0:
+                benchmark_tick_texts.append(f"<br><br><b>{benchmark_ticks[benchmark_tickvals[i]]}</b>")
+            else:
+                date_diff = (benchmark_tickvals[i] - benchmark_tickvals[i - 1]).days
+                if date_diff <= 75:
+                    benchmark_tick_texts.append(f"<br><br><br><b>{benchmark_ticks[benchmark_tickvals[i]]}</b>")
+                else:
+                    benchmark_tick_texts.append(f"<br><br><b>{benchmark_ticks[benchmark_tickvals[i]]}</b>")
+        fig.update_xaxes(
+            tickvals=filtered_custom_tickvals + benchmark_tickvals,  # Use filtered_custom_tickvals
+            ticktext=[f"{date.strftime('%b')}<br>{date.strftime('%y')}" for date in filtered_custom_tickvals] + 
+                      benchmark_tick_texts,  # Use the new benchmark tick texts
+            tickangle=0,
+            tickfont=dict(size=10)
+        )
+        fig.update_yaxes(range=[0, 110]) # Set y-axis range to 110 for better visibility of legend and avoiding overlap with interactivity block of plotly on top-right
+        display_mode = 'lines+markers'
+    else:
+        fig.update_xaxes(
+            tickvals=custom_tickvals + benchmark_tickvals,  # Use filtered_custom_tickvals
+            ticktext=[f"{date.strftime('%b')} {date.strftime('%Y')}" for date in custom_tickvals] + 
+                    [f"<br><span style='font-size:12px;'><b>{benchmark_ticks[date]}</b></span>" for date in benchmark_tickvals],  # Added <br> for vertical alignment
+            tickangle=0,
+            tickfont=dict(size=10)  
+        )
+        fig.update_yaxes(range=[0, max_clemscore+10])
+        display_mode = 'lines+markers+text'
+
+
+    # Add lines connecting the points for open models
+    fig.add_trace(go.Scatter(x=df_open['Release date'], y=df_open['clemscore'],
+                            mode=display_mode,  # Include 'text' in the mode
+                            name='Open Models Trendline',
+                            text=df_open['label_model'],  # Use label_model for text labels
+                            textposition='top center',  # Position of the text labels
+                            line=dict(color=open_color), showlegend=False))
+
+    # Add lines connecting the points for commercial models
+    fig.add_trace(go.Scatter(x=df_commercial['Release date'], y=df_commercial['clemscore'],
+                            mode=display_mode,  # Include 'text' in the mode
+                            name='Commercial Models Trendline',
+                            text=df_commercial['label_model'],  # Use label_model for text labels
+                            textposition='top center',  # Position of the text labels
+                            line=dict(color=comm_color), showlegend=False))
+
+
+    # Update layout to ensure text labels are visible   
+    fig.update_traces(textposition='top center')
+
+    # Update the Legend Position and plot dimensions
+    fig.update_layout(height=height,
+        legend=dict(
+            yanchor="top",
+            y=0.99,
+            xanchor="left",
+            x=0.01
+        ) 
+    )
+
+    if width:
+        print("Custom Setting Width :")
+        fig.update_layout(width=width)
+
+    return fig
+
+def get_final_trend_plot(mobile_view: bool = False, custom_width: int = 0) -> go.Figure:
+    """Fetch and generate the final trend plot for all models.
+
+    Args:
+        custom_width: The custom width to use for loading the graph first time.
+        mobile_view (bool, optional): Flag to indicate mobile view. Defaults to False.
+
+    Returns:
+        go.Figure: The generated trend plot for selected benchmark.
+    """
+    # Fetch Model Registry
+    response = requests.get(REGISTRY_URL)
+    model_registry_data = response.json()
+    # Custom tick labels
+    json_url = REPO + BENCHMARK_FILE
+    response = requests.get(json_url)
+
+    # Check if the JSON file request was successful
+    if response.status_code != 200:
+        print(f"Failed to read JSON file: Status Code: {response.status_code}")
+
+    json_data = response.json()
+    versions = json_data['versions']
+
+    if mobile_view:
+        height = 450
+        width = 375
+    else:
+        height = 1000
+        width = None
+
+    if custom_width:
+        width = custom_width
+
+    plot_kwargs = {'height': height, 'width': width, 'open_dip': 0, 'comm_dip': 0,
+                   'mobile_view': mobile_view}
+
+    benchmark_ticks = {}
+    benchmark_update = {}
+    mm_dfs = get_github_data()['multimodal']['dataframes']
+    result_df = get_trend_data(mm_dfs, model_registry_data)
+    df = result_df
+    for ver in versions:
+        if 'multimodal' in ver['version']:
+            temp_ver = ver['version']
+            temp_ver = temp_ver.replace('_multimodal', '')
+            benchmark_ticks[pd.to_datetime(ver['release_date'])] = temp_ver ## MM benchmark dates considered after v1.6 (incl.)
+            benchmark_update[pd.to_datetime(ver['last_updated'])] = temp_ver
+
+    fig = get_plot(df, start_date=START_DATE, end_date=datetime.now().strftime('%Y-%m-%d'), benchmark_ticks=benchmark_ticks, benchmark_update=benchmark_update, **plot_kwargs)
+
+    return fig

--- a/src/version_utils.py
+++ b/src/version_utils.py
@@ -1,7 +1,3 @@
-## REQUIRED OUTPUT ###
-# A list of version names -> v1.6, v.6_multimodal, v1.6_quantized, v1.5, v0.9, etc......
-# A corresponding DataFrame?
-
 import requests
 from datetime import datetime
 import pandas as pd
@@ -9,18 +5,18 @@ import json
 from io import StringIO
 
 from src.leaderboard_utils import process_df
-from src.assets.text_content import REPO
+from src.assets.text_content import REPO, BENCHMARK_FILE
 
-def get_versions_data():
+def get_version_data():
     """
-    Read and process data from CSV files of all available versions hosted on GitHub. - https://github.com/clembench/clembench-runs
+    Read and process data from CSV files of all available multimodal versions hosted on GitHub. - https://github.com/clembench/clembench-runs
 
     Returns:
-        versions_data:
+        version_data:
             -
     """
     base_repo = REPO
-    json_url = base_repo + "benchmark_runs.json"
+    json_url = base_repo + BENCHMARK_FILE
     response = requests.get(json_url)
 
     # Check if the JSON file request was successful
@@ -33,42 +29,35 @@ def get_versions_data():
 
     version_names = sorted(
         [ver['version'] for ver in versions],
-        key=lambda v: list(map(int, v[1:].split('_')[0].split('.'))),  # {{ edit_1 }}: Corrected slicing to handle 'v' prefix
+        key=lambda v: list(map(int, v[1:].split('_')[0].split('.'))),  
         reverse=True
     )   
 
-    # Get Last updated date of the latest version
-    latest_version = version_names[0]
-    latest_date = next(
-        ver['date'] for ver in versions if ver['version'] == latest_version
-    )
-    formatted_date = datetime.strptime(latest_date, "%Y-%m-%d").strftime("%d %b %Y")  # {{ edit_1 }}: Updated date format
-
-    # Get Versions data
-    versions_data = {"latest": latest_version, "date": formatted_date}
-
+    version_data  = {
+        'versions': [],
+        'dataframes': []
+    }
 
     for version in version_names:
-        if version.endswith("multimodal"):
-            version_suffix = ""
-        else:
-            version_suffix = "_multimodal"
+        if 'multimodal' in version: # Only include multimodal versions
+            base_url = f"{base_repo}{version}/results.csv"
+            response = requests.get(base_url)
+            if response.status_code == 200:
+                df = pd.read_csv(StringIO(response.text))
+                df = process_df(df)
+                df = df.sort_values(by=df.columns[1], ascending=False)  # Sort by clemscore column
+                version_data['dataframes'].append(df)
+                metadata = {
+                    'name': version,
+                    'last_updated': [datetime.strptime(v['last_updated'], '%Y-%m-%d').strftime("%d %b %Y") for v in versions if v['version'] == version],
+                    'release_date': [datetime.strptime(v['release_date'], '%Y-%m-%d').strftime("%d %b %Y") for v in versions if v['version'] == version]
+                } 
+                version_data['versions'].append(metadata)
 
-        mm_url = f"{base_repo}{version}{version_suffix}/results.csv"
 
-        # Multimodal Data
-        mm_response = requests.get(mm_url)
-        if mm_response.status_code == 200:
-            mm_df = pd.read_csv(StringIO(mm_response.text))
-            mm_df = process_df(mm_df)
-            mm_df = mm_df.sort_values(by=mm_df.columns[1], ascending=False)  # Sort by clemscore column
-            versions_data[version+version_suffix] = mm_df
-        else:
-            print(f"Failed to read multimodal leaderboard CSV file for version: {version}: Status Code: {mm_response.status_code}. Please ignore this message if multimodal results are not available for this version")
-
-    return versions_data
+    return version_data
 
 
 if __name__ == "__main__":
-    versions_data = get_versions_data()
-    print(versions_data.keys())
+    version_data = get_version_data()
+    print(version_data['versions'])


### PR DESCRIPTION
- Add hover info for vertical-dotted lines for benchmark versions
- Set dip to 0
- Increase font size for benchmark tickvals on x-axis
- Remove `size = sqrt (params)` form hover info of models
- Update github data loading to include `last_updated` and `release_date`
- Benchmark versions displayed on the trendgraph are only based on the versions specified in `benchmark_runs.json`
- In `versions` tab, all suffixes are included `backends`, `quantized` and `ascii`. To exclude/include any change this list - https://huggingface.co/spaces/Koshti10/clem-leaderboard/blob/66dd1512e70932b9b76428eaea89cadebc7f5413/src/version_utils.py#L14 