### PR TITLE
add default plots, optimize mobile view

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,6 +54,12 @@ def select_version_df(name):
         if v['name'] == name:
             return versions_data['dataframes'][i]
 
+
+models_list = multimodal_leaderboard.iloc[:, 0].unique().tolist()
+open_models, commercial_models = split_models(models_list)
+initial_plot = plotly_plot(df=multimodal_leaderboard, list_op=open_models, list_co=commercial_models,
+                         show_all=["Show All Models"], show_names=["Show Names"], show_legend=[],
+                           mobile_view=[], custom_width=1200)
 """
 MAIN APPLICATION
 """
@@ -126,7 +132,7 @@ with hf_app:
                     show_all = gr.CheckboxGroup(
                         ["Select All Models"],
                         label="Show plot for all models 🤖",
-                        value=[],
+                        value="Select All Models",
                         elem_id="value-select-3",
                         interactive=True,
                     )
@@ -135,7 +141,7 @@ with hf_app:
                     show_names = gr.CheckboxGroup(
                         ["Show Names"],
                         label="Show names of models on the plot 🏷️",
-                        value=[],
+                        value="Show Names",
                         elem_id="value-select-4",
                         interactive=True,
                     )
@@ -171,7 +177,7 @@ with hf_app:
             with gr.Row():
                 with gr.Column():
                     # Output block for the plot
-                    plot_output = gr.Plot()
+                    plot_output = gr.Plot(initial_plot)
 
             """
             PLOT CHANGE ACTIONS
@@ -245,9 +251,6 @@ with hf_app:
                 mkd_text = gr.Markdown("### Commercial v/s Open-Weight models - clemscore over time.  The size of the circles represents the scaled value of the parameters of the models. Larger circles indicate higher parameter values.")
 
             with gr.Row():
-                trend_plot = gr.Plot(get_final_trend_plot(False, 1200), show_label=False)
-
-            with gr.Row():
                 mobile_view = gr.CheckboxGroup(
                     choices=["Mobile View"],
                     value=[],
@@ -255,6 +258,9 @@ with hf_app:
                     elem_id="value-select-8",
                     interactive=True,
                 )
+
+            with gr.Row():
+                trend_plot = gr.Plot(get_final_trend_plot(False, 1200), show_label=False)
 
             mobile_view.change(
                 get_final_trend_plot,

--- a/src/plot_utils.py
+++ b/src/plot_utils.py
@@ -10,7 +10,7 @@ from src.leaderboard_utils import get_github_data
 
 def plotly_plot(df: pd.DataFrame, list_op: list, list_co: list,
                 show_all: list, show_names: list, show_legend: list,
-                mobile_view: list):
+                mobile_view: list, custom_width: int = None):
     """
     Takes in a list of models for a plotly plot
     Args:
@@ -62,22 +62,27 @@ def plotly_plot(df: pd.DataFrame, list_op: list, list_co: list,
     fig.update_yaxes(range=[-5, 105])
 
     if mobile_view:
-        fig.update_layout(height=300)
-
-    if mobile_view and show_legend:
-        fig.update_layout(height=450)
-        fig.update_layout(legend=dict(
-            yanchor="bottom",
-            y=-5.52,
-            xanchor="left",
-            x=0.01
-        ))
-
+        # Fix plot dimensions for a cleaner view
         fig.update_layout(
-            xaxis_title="",
-            yaxis_title="",
-            title="% Played v/s Quality Score"
+            height=400,  # shorter plot for mobile
+            margin=dict(l=10, r=10, t=30, b=40),
+            font=dict(size=5),
+            legend=dict(font=dict(size=7),
+                        bgcolor='rgba(255,255,255,0.7)',  # semi-transparent white for mobile
+                        bordercolor='rgba(0,0,0,0.05)',
+                        yanchor="bottom",
+                        y=-5.52,
+                        xanchor="left",
+                        x=0.01
+                        ),
+            xaxis=dict(tickfont=dict(size=7)),
+            yaxis=dict(tickfont=dict(size=7)),
+            title=dict(font=dict(size=13)),
+
         )
+
+    if custom_width:
+        fig.update_layout(width=custom_width)
 
     return fig
 

--- a/src/trend_utils.py
+++ b/src/trend_utils.py
@@ -305,14 +305,7 @@ def get_plot(df: pd.DataFrame, start_date: str = '2023-06-01', end_date: str = '
         # Alternate <br> for benchmark ticks based on date difference (Eg. v1.6, v1.6.5 too close to each other for MM benchmark)
         benchmark_tick_texts = []
         for i in range(len(benchmark_tickvals)):
-            if i == 0:
                 benchmark_tick_texts.append(f"<br><br><b>{benchmark_ticks[benchmark_tickvals[i]]}</b>")
-            else:
-                date_diff = (benchmark_tickvals[i] - benchmark_tickvals[i - 1]).days
-                if date_diff <= 75:
-                    benchmark_tick_texts.append(f"<br><br><br><b>{benchmark_ticks[benchmark_tickvals[i]]}</b>")
-                else:
-                    benchmark_tick_texts.append(f"<br><br><b>{benchmark_ticks[benchmark_tickvals[i]]}</b>")
         fig.update_xaxes(
             tickvals=filtered_custom_tickvals + benchmark_tickvals,  # Use filtered_custom_tickvals
             ticktext=[f"{date.strftime('%b')}<br>{date.strftime('%y')}" for date in filtered_custom_tickvals] + 
@@ -368,6 +361,22 @@ def get_plot(df: pd.DataFrame, start_date: str = '2023-06-01', end_date: str = '
         print("Custom Seting the Width :")
         fig.update_layout(width=width)
 
+    if mobile_view:
+        # Fix plot dimensions for a cleaner view
+        fig.update_layout(
+            height=400,  # shorter plot for mobile
+            margin=dict(l=10, r=10, t=30, b=40),
+            font=dict(size=5),
+            legend=dict(font=dict(size=7),
+                        bgcolor='rgba(255,255,255,0.7)',  # semi-transparent white for mobile
+                        bordercolor='rgba(0,0,0,0.05)'),
+            xaxis=dict(tickfont=dict(size=7)),
+            yaxis=dict(tickfont=dict(size=7)),
+            title=dict(font=dict(size=13)),
+
+        )
+
+
     return fig
 
 def get_final_trend_plot(mobile_view: bool = False, custom_width: int = 0) -> go.Figure:
@@ -396,15 +405,10 @@ def get_final_trend_plot(mobile_view: bool = False, custom_width: int = 0) -> go
 
     if mobile_view:
         height = 450
-        width = 375
     else:
         height = 1000
-        width = None
 
-    if custom_width:
-        width = custom_width
-
-    plot_kwargs = {'height': height, 'width': width, 'open_dip': 0, 'comm_dip': 0,
+    plot_kwargs = {'height': height, 'width': custom_width, 'open_dip': 0, 'comm_dip': 0,
                    'mobile_view': mobile_view}
 
     benchmark_ticks = {}


### PR DESCRIPTION
- Add a default plot for `Plots` tabs
- Set an initial `custom_width` of `1200` for plots to fix squishing plot issue
- Remove width arg from `mobile_view` and make the legend transparent
- Reduce fonts, and triple break lines when using `mobile_view`